### PR TITLE
Add library support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @beaugunderson

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @beaugunderson

--- a/README.md
+++ b/README.md
@@ -3,16 +3,34 @@
 A tool for interacting with GitHub's
 [CODEOWNERS](https://help.github.com/articles/about-codeowners/) files.
 
+Usable as a CLI, or as a library.
+
 ## installation
 
 ```sh
 $ npm install -g codeowners
 ```
 
-## usage
+## cli usage
+
+Print a list of each files in the current repo, followed by its owner:
+
+```sh
+$ codeowners audit
+```
 
 To find a list of files not covered by the `CODEOWNERS` in the project:
 
 ```sh
 $ codeowners audit --unowned
+```
+
+## library usage
+
+```js
+const Codeowners = require('codeowners');
+
+// workingDir is optional, defaults to process.cwd()
+const repos = new Codeowners(workingDir);
+repos.getOwner('path/to/file.js'); // => array of owner strings, e.g. ['@noahm']
 ```

--- a/codeowners.js
+++ b/codeowners.js
@@ -18,7 +18,7 @@ function Codeowners(currentPath) {
     currentPath = process.cwd();
   }
 
-  this.codeownersFilePath = trueCasePath(findUp.sync('.github/CODEOWNERS', { cwd: currentPath }));
+  this.codeownersFilePath = trueCasePath(findUp.sync(['.github/CODEOWNERS', 'docs/CODEOWNERS', 'CODEOWNERS'], { cwd: currentPath }));
 
   this.codeownersDirectory = path.dirname(path.dirname(this.codeownersFilePath));
   const codeownersFile = path.basename(this.codeownersFilePath);

--- a/codeowners.js
+++ b/codeowners.js
@@ -10,10 +10,7 @@ const trueCasePath = require('true-case-path');
 
 function ownerMatcher(pathString) {
   const matcher = ignore().add(pathString);
-
-  return function (fileString) {
-    return matcher.ignores(fileString);
-  };
+  return matcher.ignores.bind(matcher);
 }
 
 function Codeowners(currentPath) {

--- a/codeowners.js
+++ b/codeowners.js
@@ -1,26 +1,12 @@
-#!/usr/bin/env node
-
+// @ts-check
 'use strict';
 
 const findUp = require('find-up');
 const fs = require('fs');
 const ignore = require('ignore');
 const isDirectory = require('is-directory');
-const maxBy = require('lodash.maxby');
-const padEnd = require('lodash.padend');
 const path = require('path');
-const program = require('commander');
-const recursive = require('recursive-readdir');
 const trueCasePath = require('true-case-path');
-
-const codeownersPath = findUp.sync('CODEOWNERS', {cwd: process.cwd()});
-const trueCaseCodeownersPath = trueCasePath(codeownersPath);
-
-const codeownersDirectory = path.dirname(trueCaseCodeownersPath);
-const codeownersFile = path.basename(trueCaseCodeownersPath);
-
-// TODO make a command-line option, and find .git
-const rootPath = process.cwd();
 
 function ownerMatcher(pathString) {
   const matcher = ignore().add(pathString);
@@ -30,89 +16,56 @@ function ownerMatcher(pathString) {
   };
 }
 
-const gitignorePath = findUp.sync('.gitignore', {cwd: rootPath});
-const gitignoreMatcher = ignore();
-
-if (gitignorePath) {
-  gitignoreMatcher.add(fs.readFileSync(gitignorePath).toString());
-}
-
-if (codeownersFile !== 'CODEOWNERS') {
-  console.log(`Found a CODEOWNERS file but it was lower-cased: ${trueCaseCodeownersPath}`);
-
-  process.exit(1);
-}
-
-if (isDirectory.sync(trueCaseCodeownersPath)) {
-  console.error(`Found a CODEOWNERS but it's a directory: ${trueCaseCodeownersPath}`);
-
-  process.exit(1);
-}
-
-const lines = fs.readFileSync(trueCaseCodeownersPath).toString().split('\n');
-const ownerEntries = [];
-
-lines.forEach(line => {
-  if (!line) {
-    return;
+function Codeowners(currentPath) {
+  if (!currentPath) {
+    currentPath = process.cwd();
   }
 
-  if (line.startsWith('#')) {
-    return;
+  this.codeownersFilePath = trueCasePath(findUp.sync('.github/CODEOWNERS', { cwd: currentPath }));
+
+  this.codeownersDirectory = path.dirname(path.dirname(this.codeownersFilePath));
+  const codeownersFile = path.basename(this.codeownersFilePath);
+
+  if (codeownersFile !== 'CODEOWNERS') {
+    throw new Error(`Found a CODEOWNERS file but it was lower-cased: ${this.codeownersFilePath}`);
   }
 
-  const [pathString, ...usernames] = line.split(/\s+/);
+  if (isDirectory.sync(this.codeownersFilePath)) {
+    throw new Error(`Found a CODEOWNERS but it's a directory: ${this.codeownersFilePath}`);
+  }
 
-  ownerEntries.push({
-    path: pathString,
-    usernames: usernames,
-    match: ownerMatcher(pathString)
-  });
-});
+  const lines = fs.readFileSync(this.codeownersFilePath).toString().split('\n');
+  const ownerEntries = [];
 
-program
-  .command('audit')
-  .description('list the owners for all files')
-  .option('-u, --unowned', 'unowned files only')
-  .action(options => {
-    recursive(rootPath, ['.git', 'node_modules'], (err, files) => {
-      if (err) {
-        console.error(err);
+  for (const line of lines) {
+    if (!line) {
+      continue;
+    }
 
-        process.exit(1);
-      }
+    if (line.startsWith('#')) {
+      continue;
+    }
 
-      const filteredFiles = gitignoreMatcher.filter(files).sort();
-      const relativeFiles = filteredFiles.map(file => path.relative(codeownersDirectory, file));
-      const maxLength = maxBy(relativeFiles, file => file.length).length;
+    const [pathString, ...usernames] = line.split(/\s+/);
 
-      relativeFiles.forEach(file => {
-        let ownerEntry;
-        let owners = 'none';
-
-        ownerEntries.forEach(entry => {
-          if (entry.match(file)) {
-            ownerEntry = entry;
-          }
-        });
-
-        if (options.unowned) {
-          if (!ownerEntry) {
-            return console.log(file);
-          }
-        } else {
-          if (ownerEntry) {
-            owners = ownerEntry.usernames.join(' ');
-          }
-
-          console.log(`${padEnd(file, maxLength)}    ${owners}`);
-        }
-      });
+    ownerEntries.push({
+      path: pathString,
+      usernames: usernames,
+      match: ownerMatcher(pathString)
     });
-  });
+  }
 
-if (!process.argv.slice(2).length) {
-  program.outputHelp();
+  this.ownerEntries = ownerEntries;
 }
 
-program.parse(process.argv);
+Codeowners.prototype.getOwner = function (filePath) {
+  let owners = [];
+  for (const entry of this.ownerEntries) {
+    if (entry.match(filePath)) {
+      owners = entry.usernames;
+    }
+  }
+  return owners.slice();
+}
+
+module.exports = Codeowners;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 // @ts-check
-
 'use strict';
 
 const findUp = require('find-up');
@@ -16,11 +15,6 @@ const Codeowners = require('./codeowners');
 
 // TODO make a command-line option, and find .git
 const rootPath = process.cwd();
-
-function ownerMatcher(pathString) {
-  const matcher = ignore().add(pathString);
-  return matcher.ignores.bind(matcher);
-}
 
 const gitignorePath = findUp.sync('.gitignore', { cwd: rootPath });
 const gitignoreMatcher = ignore();

--- a/index.js
+++ b/index.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// @ts-check
+
+'use strict';
+
+const findUp = require('find-up');
+const fs = require('fs');
+const ignore = require('ignore');
+const maxBy = require('lodash.maxby');
+const padEnd = require('lodash.padend');
+const path = require('path');
+const program = require('commander');
+const recursive = require('recursive-readdir');
+
+const Codeowners = require('./codeowners');
+
+// TODO make a command-line option, and find .git
+const rootPath = process.cwd();
+
+function ownerMatcher(pathString) {
+  const matcher = ignore().add(pathString);
+  return matcher.ignores.bind(matcher);
+}
+
+const gitignorePath = findUp.sync('.gitignore', { cwd: rootPath });
+const gitignoreMatcher = ignore();
+
+if (gitignorePath) {
+  gitignoreMatcher.add(fs.readFileSync(gitignorePath).toString());
+}
+
+program
+  .command('audit')
+  .description('list the owners for all files')
+  .option('-u, --unowned', 'unowned files only')
+  .action(options => {
+    const codeowners = new Codeowners(rootPath);
+
+    recursive(rootPath, ['.git', 'node_modules'], (err, files) => {
+      if (err) {
+        console.error(err);
+
+        process.exit(1);
+      }
+
+      const relativeFiles = files.map(file => path.relative(codeowners.codeownersDirectory, file));
+      const filteredFiles = relativeFiles.filter(gitignoreMatcher.createFilter()).sort();
+      const maxLength = maxBy(filteredFiles, file => file.length).length;
+
+      filteredFiles.forEach(file => {
+        let owners = codeowners.getOwner(file);
+        if (options.unowned) {
+          if (!owners.length) {
+            return console.log(file);
+          }
+        } else {
+          let owner = 'nobody';
+          if (owners.length) {
+            owner = owners.join(' ');
+          }
+          console.log(`${padEnd(file, maxLength)}    ${owners}`);
+        }
+      });
+    });
+  });
+
+if (!process.argv.slice(2).length) {
+  program.outputHelp();
+}
+
+program.parse(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,11 +91,6 @@
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
     },
-    "lodash.without": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "codeowners",
   "version": "1.0.1",
   "description": "A tool for working with CODEOWNERS files",
-  "main": "index.js",
+  "main": "codeowners.js",
   "bin": {
-    "codeowners": "./codeowners.js"
+    "codeowners": "./index.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -13,7 +13,10 @@
     "codeowners",
     "github"
   ],
-  "author": "Beau Gunderson <beau@beaugunderson.com> (https://beaugunderson.com/)",
+  "contributors": [
+    "Beau Gunderson <beau@beaugunderson.com> (https://beaugunderson.com/)",
+    "Noah Manneschmidt (https://noah.manneschmidt.net/)"
+  ],
   "license": "MIT",
   "dependencies": {
     "commander": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "codeowners",
   "version": "1.0.1",
   "description": "A tool for working with CODEOWNERS files",
-  "main": "codeowners.js",
+  "main": "index.js",
   "bin": {
     "codeowners": "./codeowners.js"
   },


### PR DESCRIPTION
This adds support for use as a library in more complex tasks using codeowners files, see changes to the README.

Code that deals with parsing the CODEOWNERS file remains in `codeowners.js` while the CLI portions have been moved to `index.js`.

This also fixes #2 in the process. :)