### PR TITLE
Add support for .gitlab folder

### DIFF
--- a/codeowners.d.ts
+++ b/codeowners.d.ts
@@ -1,7 +1,7 @@
 interface Codeowners {
   /**
    * Searches upwards for a codeowners file either in a direct
-   * parent or within a docs/ or .github/ folder in a parent
+   * parent or within a docs/ or .github/ or .gitlab/ folder in a parent
    * folder of the cwd.
    * @param cwd current directory, defaults to process.cwd()
    */

--- a/codeowners.js
+++ b/codeowners.js
@@ -18,12 +18,12 @@ function Codeowners(currentPath) {
     currentPath = process.cwd();
   }
 
-  this.codeownersFilePath = trueCasePath(findUp.sync(['.github/CODEOWNERS', 'docs/CODEOWNERS', 'CODEOWNERS'], {cwd: currentPath}));
+  this.codeownersFilePath = trueCasePath(findUp.sync(['.github/CODEOWNERS', '.gitlab/CODEOWNERS', 'docs/CODEOWNERS', 'CODEOWNERS'], {cwd: currentPath}));
 
   this.codeownersDirectory = path.dirname(this.codeownersFilePath);
-  // We might have found a bare codeowners file or one inside the two supported subdirectories.
+  // We might have found a bare codeowners file or one inside the three supported subdirectories.
   // In the latter case the project root is up another level.
-  if (this.codeownersDirectory.match(/\/(.github|docs)$/i)) {
+  if (this.codeownersDirectory.match(/\/(.github|.gitlab|docs)$/i)) {
     this.codeownersDirectory = path.dirname(this.codeownersDirectory);
   }
   const codeownersFile = path.basename(this.codeownersFilePath);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "keywords": [
     "codeowners",
-    "github"
+    "github",
+    "gitlab"
   ],
   "contributors": [
     "Beau Gunderson <beau@beaugunderson.com> (https://beaugunderson.com/)",


### PR DESCRIPTION
Gitlab also supports `CODEOWNERS` files, detailed [here](https://docs.gitlab.com/ee/user/project/code_owners.html). This adds support for `CODEOWNERS` files in the `.gitlab` folder.