### PR TITLE
fix broken symlinks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -130,24 +130,6 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "recursive-readdir": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
-      "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
-      "requires": {
-        "minimatch": "3.0.3"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        }
-      }
-    },
     "true-case-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "is-directory": "^0.3.1",
     "lodash.maxby": "^4.6.0",
     "lodash.padend": "^4.6.1",
-    "recursive-readdir": "^2.2.1",
     "true-case-path": "^1.0.2"
   },
   "devDependencies": {},


### PR DESCRIPTION
Fixes #4.

Due to a bug in `recursive-readdir`, broken symlinks will make
codeowners crash. Quick reproduction:

```
$ ln -s dest source
$ codeowners audit

{ [Error: ENOENT: no such file or directory, stat 'source']
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: 'source'
```

Fix this by replacing `recursive-readdir` with our own `walk()` function
that won't crash on symlinks.