### PR TITLE
feature: verify ownership command

### DIFF
--- a/codeowners.d.ts
+++ b/codeowners.d.ts
@@ -5,7 +5,7 @@ interface Codeowners {
    * folder of the cwd.
    * @param cwd current directory, defaults to process.cwd()
    */
-  new (cwd?: string): CodeownersFile;
+  new(cwd?: string, fileName?: string): CodeownersFile;
 }
 
 interface CodeownersFile {

--- a/codeowners.js
+++ b/codeowners.js
@@ -13,12 +13,14 @@ function ownerMatcher(pathString) {
   return matcher.ignores.bind(matcher);
 }
 
-function Codeowners(currentPath) {
+function Codeowners(currentPath, fileName = "CODEOWNERS") {
   if (!currentPath) {
     currentPath = process.cwd();
   }
 
-  this.codeownersFilePath = trueCasePath(findUp.sync(['.github/CODEOWNERS', '.gitlab/CODEOWNERS', 'docs/CODEOWNERS', 'CODEOWNERS'], {cwd: currentPath}));
+  this.codeownersFilePath = trueCasePath(findUp.sync([
+    `.github/${fileName}`, `.gitlab/${fileName}`, `docs/${fileName}`, `${fileName}`
+  ], { cwd: currentPath }));
 
   this.codeownersDirectory = path.dirname(this.codeownersFilePath);
   // We might have found a bare codeowners file or one inside the three supported subdirectories.
@@ -28,12 +30,12 @@ function Codeowners(currentPath) {
   }
   const codeownersFile = path.basename(this.codeownersFilePath);
 
-  if (codeownersFile !== 'CODEOWNERS') {
-    throw new Error(`Found a CODEOWNERS file but it was lower-cased: ${this.codeownersFilePath}`);
+  if (codeownersFile !== fileName) {
+    throw new Error(`Found a ${fileName} file but it was lower-cased: ${this.codeownersFilePath}`);
   }
 
   if (isDirectory.sync(this.codeownersFilePath)) {
-    throw new Error(`Found a CODEOWNERS but it's a directory: ${this.codeownersFilePath}`);
+    throw new Error(`Found a ${fileName} but it's a directory: ${this.codeownersFilePath}`);
   }
 
   const lines = fs.readFileSync(this.codeownersFilePath).toString().split('\n');

--- a/index.js
+++ b/index.js
@@ -89,11 +89,10 @@ program
   });
 
 program
-  .command("verify <path>")
-  .description("verify ownership of a specific path")
-  .requiredOption('-u, --users <users...>', 'verify ownership by these users or teams')
+  .command("verify <path> <users...>")
+  .description("verify users/teams own a specific path")
   .option('-c, --codeowners-filename <codeowners_filename>', 'specify CODEOWNERS filename', "CODEOWNERS")
-  .action((path, options) => {
+  .action((path, users, options) => {
     // instantiate new Codeowners obj
     const codeowners = new Codeowners(rootPath, options.codeownersFilename);
 
@@ -101,7 +100,7 @@ program
     const owners = codeowners.getOwner(path);
 
     // check if any `users` are in the results of getOwner()
-    const verifiedOwners = intersection(options.users, owners);
+    const verifiedOwners = intersection(users, owners);
 
     // if verifiedOwners is empty, exit with error
     if (verifiedOwners.length < 1) {

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ program
   .option('-u, --unowned', 'unowned files only')
   .option('-c, --codeowners-filename <codeowners_filename>', 'specify CODEOWNERS filename', "CODEOWNERS")
   .action(options => {
-    const codeowners = new Codeowners(rootPath, options.codeOwnersFilename);
+    const codeowners = new Codeowners(rootPath, options.codeownersFilename);
 
     walk(rootPath, ['.git', 'node_modules'], (err, files) => {
       if (err) {
@@ -95,7 +95,7 @@ program
   .option('-c, --codeowners-filename <codeowners_filename>', 'specify CODEOWNERS filename', "CODEOWNERS")
   .action((path, options) => {
     // instantiate new Codeowners obj
-    const codeowners = new Codeowners(rootPath, options.codeOwnersFilename);
+    const codeowners = new Codeowners(rootPath, options.codeownersFilename);
 
     // call getOwner() on `path`
     const owners = codeowners.getOwner(path);

--- a/index.js
+++ b/index.js
@@ -53,8 +53,9 @@ program
   .command('audit')
   .description('list the owners for all files')
   .option('-u, --unowned', 'unowned files only')
+  .option('-c, --codeowners-filename <codeowners_filename>', 'specify CODEOWNERS filename', "CODEOWNERS")
   .action(options => {
-    const codeowners = new Codeowners(rootPath);
+    const codeowners = new Codeowners(rootPath, options.codeOwnersFilename);
 
     walk(rootPath, ['.git', 'node_modules'], (err, files) => {
       if (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.0.0.tgz",
+      "integrity": "sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -80,6 +80,11 @@
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
       }
+    },
+    "lodash.intersection": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
+      "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
     },
     "lodash.maxby": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "commander": "^2.11.0",
+    "commander": "^6.0.0",
     "find-up": "^2.1.0",
     "ignore": "^3.3.3",
     "is-directory": "^0.3.1",
+    "lodash.intersection": "^4.4.0",
     "lodash.maxby": "^4.6.0",
     "lodash.padend": "^4.6.1",
     "true-case-path": "^1.0.2"


### PR DESCRIPTION
Hi there!

I propose here a subcommand that let's you verify ownership of a specific path!  The expected use case is CI/CD automation so it will exit with an error when verification fails.

```sh
$ node ./index.js verify README.md @chrispblink
None of the users/teams specified own the path README.md
$ echo $?
1

$ node ./index.js verify README.md @beaugunderson
README.md    @beaugunderson
```