### PR TITLE
Use regular expression for splitting up CODEOWNERS into lines

### DIFF
--- a/codeowners.js
+++ b/codeowners.js
@@ -38,7 +38,7 @@ function Codeowners(currentPath, fileName = 'CODEOWNERS') {
     throw new Error(`Found a ${fileName} but it's a directory: ${this.codeownersFilePath}`);
   }
 
-  const lines = fs.readFileSync(this.codeownersFilePath).toString().split('\n');
+  const lines = fs.readFileSync(this.codeownersFilePath).toString().split(/\r\n|\r|\n/);
   const ownerEntries = [];
 
   for (const line of lines) {


### PR DESCRIPTION
Previous implementation always used `\n` to split lines, but this approach only works for CODEOWNERS files that use UNIX-style linebreaks  
Old Mac-style linebreaks would result in a single line ignoring `\r` linebreaks  
Windows-style linebreaks `\r\n` would result in an additional empty username per line because the username split `\s` would trigger on `\r`

The new implementation is platform-independent.

For more details check for example https://stackoverflow.com/a/52947649