### PR TITLE
reverse the owner entries

### DIFF
--- a/codeowners.js
+++ b/codeowners.js
@@ -68,7 +68,9 @@ function Codeowners(currentPath, fileName = 'CODEOWNERS') {
     });
   }
 
-  this.ownerEntries = ownerEntries;
+  // reverse the owner entries to search from bottom to top
+  // the last matching pattern takes the most precedence
+  this.ownerEntries = ownerEntries.reverse();
 }
 
 const EMPTY_ARRAY = [];


### PR DESCRIPTION
The last matching pattern takes the most precedence in CODEOWNERS file according to the github docs: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file.

However, this behavior [was changed in v5.0.2](https://github.com/beaugunderson/codeowners/compare/v5.0.1...v5.0.2#diff-7707989524934ca12bc73b9ea39792ac2038a5aabd0ad0365366d8f995793bc1L75-L84), this PR reverse the searching order so the last matching pattern will be used instead.