### PR TITLE
Fix filtering node_modules and .git dirs

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ program
     const padding = parseInt(options.width, 10);
 
     const stream = walkStream(rootPath, {
-      filter: (entry) => !entry.path.startsWith('node_modules') && !entry.path.startsWith('.git'),
+      deepFilter: (entry) => !entry.path.startsWith('node_modules') && !entry.path.startsWith('.git'),
       errorFilter: (error) =>
         error.code === 'ENOENT' || error.code === 'EACCES' || error.code === 'EPERM',
     });


### PR DESCRIPTION
According to v1.2.6, `filter` option is named `deepFilter`: https://github.com/nodelib/nodelib/tree/@nodelib/fs.walk@1.2.6/packages/fs/fs.walk#deepfilter.

Fixes #21 