### PR TITLE
Fix finding codeownersDirectory on windows with parent folder

### DIFF
--- a/codeowners.js
+++ b/codeowners.js
@@ -12,11 +12,13 @@ function ownerMatcher(pathString) {
   return matcher.ignores.bind(matcher);
 }
 
+const PARENT_FOLDERS = ['.github', '.gitlab', 'docs'];
+
 function Codeowners(currentPath, fileName = 'CODEOWNERS') {
   const pathOrCwd = currentPath || process.cwd();
 
   const codeownersPath = findUp.sync(
-    [`.github/${fileName}`, `.gitlab/${fileName}`, `docs/${fileName}`, `${fileName}`],
+    PARENT_FOLDERS.map((folder) => path.join(folder, fileName)).concat(fileName),
     { cwd: pathOrCwd }
   );
 
@@ -30,7 +32,7 @@ function Codeowners(currentPath, fileName = 'CODEOWNERS') {
 
   // We might have found a bare codeowners file or one inside the three supported subdirectories.
   // In the latter case the project root is up another level.
-  if (this.codeownersDirectory.match(/\/(.github|.gitlab|docs)$/i)) {
+  if (PARENT_FOLDERS.includes(path.basename(this.codeownersDirectory))) {
     this.codeownersDirectory = path.dirname(this.codeownersDirectory);
   }
 


### PR DESCRIPTION
Hey, long time! This library has continued to be super useful at Twitch over the years! We happened to notice today that the regex I added years ago wasn't correctly matching when run on a windows environment (uses a backslash) and resulted in the wrong `codeownersDirectory` being set when used in a repo that put the CODEOWNERS file under one of the parent folders.

This may also fix #16 depending on what the reporter's original issue was, but without more context that's impossible to say.