### PR TITLE
Ignore yarn cache files

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ program
     const stream = walkStream(rootPath, {
       deepFilter: (entry) => {
         const split = entry.path.split(path.sep);
-        return !split.includes('node_modules') && !split.includes('.git');
+        return !split.includes('node_modules') && !split.includes('.git') && !split.includes('.cache');
       },
       errorFilter: (error) =>
         error.code === 'ENOENT' || error.code === 'EACCES' || error.code === 'EPERM',


### PR DESCRIPTION
We use yarn instead of npm, and yarn installs the deps in `.cache/yarn/`. The library is not taking this into account, and it's returning all yarn dependencies as unowned.