### PR TITLE
Ensure we respect inline comments

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @beaugunderson
+* @beaugunderson # I own the whole project!

--- a/codeowners.js
+++ b/codeowners.js
@@ -59,13 +59,17 @@ function Codeowners(currentPath, fileName = 'CODEOWNERS') {
       continue;
     }
 
-    const [pathString, ...usernames] = line.split(/\s+/);
+    const [data, ...comment] = line.split("#");
+    const [pathString, ...usernames] = data.split(/\s+/);
 
-    ownerEntries.push({
+    const entry = {
       path: pathString,
-      usernames,
+      usernames: usernames.filter(Boolean),
       match: ownerMatcher(pathString),
-    });
+    }
+    if(comment && comment.length) entry.comment = comment.join("")
+
+    ownerEntries.push(entry);
   }
 
   // reverse the owner entries to search from bottom to top

--- a/codeowners.test.js
+++ b/codeowners.test.js
@@ -15,4 +15,8 @@ describe('codeowners', () => {
     const owner = repos.getOwner(__filename);
     expect(owner).toEqual(['@beaugunderson']);
   });
+
+  it('respects inline comments', () => {
+    expect(repos.ownerEntries[0].comment).toEqual(" I own the whole project!")
+  });
 });


### PR DESCRIPTION
`#` Comments are valid inline in a codeowners file, but we currently treat them as more usernames. This change ensures we treat comments as such and strip them from the usernames. I have chosen to include the comment string in the underlying datastructure because it could be useful (and makes sense to me that a parser would not drop information).

Thanks @beaugunderson for your work on this project